### PR TITLE
Widen Gantt zoom range from 25%-200% to 5%-300%

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -849,7 +849,7 @@ export default function App() {
 
       setGanttScale(s.ganttScale === 'week' ? 'week' : 'day');
       const zoom = parseInt(s.ganttZoom, 10);
-      setGanttZoom(Number.isFinite(zoom) && zoom >= 25 && zoom <= 200 ? zoom : 100);
+      setGanttZoom(Number.isFinite(zoom) && zoom >= 5 && zoom <= 300 ? zoom : 100);
       const colors = extractThemeColors(s);
       applyThemeToDOM(colors);
       setActiveTheme(s.themeName || 'Notion Light');

--- a/src/components/GanttChart.jsx
+++ b/src/components/GanttChart.jsx
@@ -9,8 +9,8 @@ const BAR_HEIGHT = 16;
 const BASELINE_HEIGHT = 4;
 const SUMMARY_HEIGHT = 10;
 
-const ZOOM_MIN = 25;
-const ZOOM_MAX = 200;
+const ZOOM_MIN = 5;
+const ZOOM_MAX = 300;
 const BASE_UNIT_AT_100 = 32;
 // Extra right-side pixels reserved so task name labels that appear after
 // the last bar are not clipped by the SVG boundary.

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
 import { Plus, Calendar, CalendarDays, ZoomIn, ZoomOut } from 'lucide-react';
 
-const ZOOM_MIN = 25;
-const ZOOM_MAX = 200;
+const ZOOM_MIN = 5;
+const ZOOM_MAX = 300;
 const ZOOM_STEP = 10;
 
 export default function StatusBar({


### PR DESCRIPTION
## Summary

Widens the Gantt-tab zoom control range from `25..200` to `5..300` so users can both zoom out much further (dense full-project overview) and zoom in much closer (fine-grained detail work).

The `25..200` clamp was hard-coded in three independent places, and all three had to be widened together for the new range to actually stick:

- `src/components/StatusBar.jsx` - drives the +/- buttons' disabled state, the number-input `min`/`max`, and the commit-clamp (`handleZoomStep` / `handleZoomInputChange` / `handleZoomInputCommit`).
- `src/components/GanttChart.jsx` - re-clamps `effectiveZoom` at render time, so without this change the chart would silently snap any wider value back into `25..200`.
- `src/App.jsx` - import-time validation of `ganttZoom` from an imported xlsx; values outside the range fall back to `100`, which would erase any wider value across a save/import cycle.

### Render safety at extremes

`GanttChart.jsx` already floor-clamps the per-unit pixel width via `baseUnit = Math.max(4, Math.round(BASE_UNIT_AT_100 * effectiveZoom / 100))`. At 5% zoom the bars stay at 4 px/day instead of collapsing sub-pixel; at 300% everything scales up linearly with no division, overflow, or wraparound.

## Test plan

- [ ] On the Gantt tab, verify the `-` button is disabled at exactly `5` and enabled at `6+`.
- [ ] Verify the `+` button is disabled at exactly `300` and enabled at `299-`.
- [ ] Type `5` into the zoom input: chart renders at minimum density (4 px/day floor visible).
- [ ] Type `300` into the zoom input: chart renders at 3x the 100% baseline.
- [ ] Type `1` or `500`: the input clamps on commit to `5` / `300` respectively.
- [ ] Save to xlsx at zoom `250`, re-import: zoom restores to `250` (not `100`).
- [ ] Import a pre-existing xlsx with zoom `150`: still restores correctly (legacy range is a subset).