### PR TITLE
Add zoom controls to datagrid tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -296,6 +296,7 @@ export default function App() {
   const [colWidths, setColWidths] = useState({});
   const [ganttScale, setGanttScale] = useState('day');
   const [ganttZoom, setGanttZoom] = useState(100);
+  const [gridZoom, setGridZoom] = useState(100);
   const [activeTab, setActiveTab] = useState('gantt');
   const [tabs, setTabs] = useState([]);
   const [gridData, setGridData] = useState({});
@@ -654,6 +655,11 @@ export default function App() {
     markDirty();
   }, [markDirty]);
 
+  const handleGridZoomChange = useCallback((v) => {
+    setGridZoom(v);
+    markDirty();
+  }, [markDirty]);
+
   const handleAddColumn = useCallback((label) => {
     const key = 'custom_' + Date.now().toString(36);
     const col = { key, label, type: 'text' };
@@ -834,6 +840,7 @@ export default function App() {
       next.colWidths = JSON.stringify(colWidths);
       next.ganttScale = ganttScale;
       next.ganttZoom = String(ganttZoom);
+      next.gridZoom = String(gridZoom);
       next.tabs = JSON.stringify(tabs);
       next.activeTab = activeTab;
       const stylesMap = {};
@@ -858,7 +865,7 @@ export default function App() {
       next.gridShapes = JSON.stringify(shapesMap);
       return next;
     });
-  }, [viewOptions, visibleColumns, categoryColors, projectName, customColumns, columnOrder, splitRatio, collapsedParents, colWidths, ganttScale, ganttZoom, tabs, activeTab, gridData]);
+  }, [viewOptions, visibleColumns, categoryColors, projectName, customColumns, columnOrder, splitRatio, collapsedParents, colWidths, ganttScale, ganttZoom, gridZoom, tabs, activeTab, gridData]);
 
   useEffect(() => {
     const handler = (e) => {
@@ -931,6 +938,8 @@ export default function App() {
       setGanttScale(s.ganttScale === 'week' ? 'week' : 'day');
       const zoom = parseInt(s.ganttZoom, 10);
       setGanttZoom(Number.isFinite(zoom) && zoom >= 5 && zoom <= 300 ? zoom : 100);
+      const gz = parseInt(s.gridZoom, 10);
+      setGridZoom(Number.isFinite(gz) && gz >= 5 && gz <= 300 ? gz : 100);
       const colors = extractThemeColors(s);
       applyThemeToDOM(colors);
       setActiveTheme(s.themeName || 'Notion Light');
@@ -1294,6 +1303,7 @@ export default function App() {
           <DataGrid
             data={gridData[activeTab]}
             onChange={(newData) => handleGridCellChange(activeTab, newData)}
+            zoomPct={gridZoom}
           />
         </div>
       )}
@@ -1304,6 +1314,8 @@ export default function App() {
         onScaleChange={handleGanttScaleChange}
         zoomPct={ganttZoom}
         onZoomChange={handleGanttZoomChange}
+        gridZoomPct={gridZoom}
+        onGridZoomChange={handleGridZoomChange}
         activeTab={activeTab}
         tabs={tabs}
         onSelectTab={handleSelectTab}

--- a/src/components/DataGrid.jsx
+++ b/src/components/DataGrid.jsx
@@ -188,7 +188,8 @@ function parseFormulaRefs(text) {
   return highlights;
 }
 
-export default function DataGrid({ data, onChange }) {
+export default function DataGrid({ data, onChange, zoomPct = 100 }) {
+  const zoomFactor = Math.max(0.05, Math.min(3, (Number.isFinite(zoomPct) ? zoomPct : 100) / 100));
   const rows = data?.rows ?? 50;
   const cols = data?.cols ?? 26;
   const cells = data?.cells ?? {};
@@ -582,14 +583,15 @@ export default function DataGrid({ data, onChange }) {
       const scrollEl = scrollRef.current;
       if (!scrollEl) return;
       const rect = scrollEl.getBoundingClientRect();
-      const x = ev.clientX - rect.left + scrollEl.scrollLeft - ROW_HEADER_WIDTH;
-      const y = ev.clientY - rect.top + scrollEl.scrollTop - HEADER_HEIGHT;
-
+      const xVis = ev.clientX - rect.left + scrollEl.scrollLeft;
+      const yVis = ev.clientY - rect.top + scrollEl.scrollTop;
+      const xL = xVis / zoomFactor - ROW_HEADER_WIDTH;
+      const yL = yVis / zoomFactor - HEADER_HEIGHT;
       let cumW = 0;
       let endCol = 0;
       for (let ci = 0; ci < cols; ci++) {
         const w = getColW(ci);
-        if (x < cumW + w) { endCol = ci; break; }
+        if (xL < cumW + w) { endCol = ci; break; }
         cumW += w;
         endCol = ci;
       }
@@ -597,7 +599,7 @@ export default function DataGrid({ data, onChange }) {
       let endRow = 0;
       for (let ri = 0; ri < rows; ri++) {
         const h = getRowH(ri);
-        if (y < cumH + h) { endRow = ri; break; }
+        if (yL < cumH + h) { endRow = ri; break; }
         cumH += h;
         endRow = ri;
       }
@@ -612,7 +614,7 @@ export default function DataGrid({ data, onChange }) {
 
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
-  }, [isFormulaEditing, editingCell, editText, insertReference, commitEdit, cols, rows, getColW, getRowH, getMergeAt, clearShapeSelection]);
+  }, [isFormulaEditing, editingCell, editText, insertReference, commitEdit, cols, rows, getColW, getRowH, getMergeAt, clearShapeSelection, zoomFactor]);
 
   const handleCellClick = useCallback(() => {
     // Selection is handled entirely in handleCellMouseDown now.
@@ -1222,7 +1224,7 @@ export default function DataGrid({ data, onChange }) {
     const key = colLabel(colIdx);
     let latestW = startWidth;
     const onMove = (e) => {
-      latestW = Math.max(MIN_COL_WIDTH, startWidth + (e.clientX - startX));
+      latestW = Math.max(MIN_COL_WIDTH, startWidth + (e.clientX - startX) / zoomFactor);
       setColWidths((prev) => ({ ...prev, [key]: latestW }));
     };
     const onUp = () => {
@@ -1242,7 +1244,7 @@ export default function DataGrid({ data, onChange }) {
     document.body.style.userSelect = 'none';
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
-  }, [onChange, data]);
+  }, [onChange, data, zoomFactor]);
 
   const handleAutoFitCol = useCallback((colIdx) => {
     const colKey = colLabel(colIdx);
@@ -1274,7 +1276,7 @@ export default function DataGrid({ data, onChange }) {
   const handleResizeRow = useCallback((rowIdx, startY, startHeight) => {
     let latestH = startHeight;
     const onMove = (e) => {
-      latestH = Math.max(MIN_ROW_HEIGHT, startHeight + (e.clientY - startY));
+      latestH = Math.max(MIN_ROW_HEIGHT, startHeight + (e.clientY - startY) / zoomFactor);
       setRowHeights((prev) => ({ ...prev, [rowIdx]: latestH }));
     };
     const onUp = () => {
@@ -1294,7 +1296,7 @@ export default function DataGrid({ data, onChange }) {
     document.body.style.userSelect = 'none';
     document.addEventListener('mousemove', onMove);
     document.addEventListener('mouseup', onUp);
-  }, [onChange, data]);
+  }, [onChange, data, zoomFactor]);
 
   const handleApplyBorderPreset = useCallback((presetId) => {
     if (!selRect || !onChange) return;
@@ -1532,7 +1534,7 @@ export default function DataGrid({ data, onChange }) {
 
       {/* Grid */}
       <div ref={scrollRef} className="flex-1 overflow-auto">
-        <div style={{ minWidth: totalWidth, position: 'relative' }}>
+        <div style={{ minWidth: totalWidth, position: 'relative', zoom: zoomFactor }}>
           {/* Column headers */}
           <div className="flex sticky top-0 z-10" style={{ backgroundColor: 'var(--color-bg-secondary)' }}>
             <div
@@ -1871,6 +1873,7 @@ export default function DataGrid({ data, onChange }) {
             shapes={shapes}
             selectedIds={selectedShapeIds}
             shapeMode={shapeMode}
+            zoomFactor={zoomFactor}
             colOffsets={colOffsets}
             rowOffsets={rowOffsets}
             rowHeaderWidth={ROW_HEADER_WIDTH}

--- a/src/components/DataGrid.jsx
+++ b/src/components/DataGrid.jsx
@@ -217,6 +217,8 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
   const editModeRef = useRef('enter');
   const isDraggingRef = useRef(false);
 
+  const [viewport, setViewport] = useState({ w: 0, h: 0 });
+
   const engineRef = useRef(null);
   const [displayValues, setDisplayValues] = useState({});
 
@@ -342,6 +344,47 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
   // requiring the user to click a cell first.
   useEffect(() => {
     containerRef.current?.focus({ preventScroll: true });
+  }, []);
+
+  // Track the scroll-viewport size so the grid can render enough padding
+  // rows/cols to fill the visible area at any zoom level.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    let rafId = 0;
+    const update = () => {
+      // offsetWidth/Height includes scrollbar width, so it stays stable
+      // even when padding rows/cols toggle scrollbar visibility. Using
+      // clientWidth/Height would feedback-loop via the ResizeObserver as
+      // scrollbars appear and disappear.
+      const w = Math.floor(el.offsetWidth);
+      const h = Math.floor(el.offsetHeight);
+      setViewport((prev) => (prev.w === w && prev.h === h ? prev : { w, h }));
+    };
+    // rAF-batch updates so state changes happen outside the RO callback,
+    // avoiding "ResizeObserver loop" errors when rendering more cells
+    // changes the container's intrinsic size.
+    const schedule = () => {
+      if (rafId) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = 0;
+        update();
+      });
+    };
+    update();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', schedule);
+      return () => {
+        window.removeEventListener('resize', schedule);
+        if (rafId) cancelAnimationFrame(rafId);
+      };
+    }
+    const ro = new ResizeObserver(schedule);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      if (rafId) cancelAnimationFrame(rafId);
+    };
   }, []);
 
   const getColW = useCallback((colIdx) => {
@@ -1434,27 +1477,67 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
     setPendingMerge(null);
   }, []);
 
+  // Pad the rendered grid so there are enough rows/columns to cover the
+  // viewport even when CSS zoom shrinks the grid content. `rows`/`cols`
+  // still track the persisted/data-backed extents; `displayRows`/`displayCols`
+  // only affect rendering (and click/arrow targets that map onto empty
+  // cells). Writing into a padded cell goes through commitEdit's usual
+  // auto-expand path, so the data dims grow naturally when the user types.
+  const displayCols = useMemo(() => {
+    if (!viewport.w) return cols;
+    const usable = viewport.w / zoomFactor - ROW_HEADER_WIDTH;
+    let acc = 0;
+    let n = 0;
+    while (acc < usable) {
+      acc += n < cols ? getColW(n) : DEFAULT_COL_WIDTH;
+      n++;
+    }
+    return Math.max(cols, n);
+  }, [cols, getColW, viewport.w, zoomFactor]);
+
+  const displayRows = useMemo(() => {
+    if (!viewport.h) return rows;
+    const usable = viewport.h / zoomFactor - HEADER_HEIGHT;
+    let acc = 0;
+    let n = 0;
+    while (acc < usable) {
+      acc += n < rows ? getRowH(n) : DEFAULT_ROW_HEIGHT;
+      n++;
+    }
+    return Math.max(rows, n);
+  }, [rows, getRowH, viewport.h, zoomFactor]);
+
+  const getDisplayColW = useCallback(
+    (ci) => (ci < cols ? getColW(ci) : DEFAULT_COL_WIDTH),
+    [cols, getColW],
+  );
+
+  const getDisplayRowH = useCallback(
+    (ri) => (ri < rows ? getRowH(ri) : DEFAULT_ROW_HEIGHT),
+    [rows, getRowH],
+  );
+
   const totalWidth = useMemo(() => {
-    return ROW_HEADER_WIDTH + Array.from({ length: cols }, (_, i) => getColW(i)).reduce((a, b) => a + b, 0);
-  }, [cols, getColW]);
+    return ROW_HEADER_WIDTH + Array.from({ length: displayCols }, (_, i) => getDisplayColW(i)).reduce((a, b) => a + b, 0);
+  }, [displayCols, getDisplayColW]);
 
   const totalHeight = useMemo(() => {
-    return HEADER_HEIGHT + Array.from({ length: rows }, (_, i) => getRowH(i)).reduce((a, b) => a + b, 0);
-  }, [rows, getRowH]);
+    return HEADER_HEIGHT + Array.from({ length: displayRows }, (_, i) => getDisplayRowH(i)).reduce((a, b) => a + b, 0);
+  }, [displayRows, getDisplayRowH]);
 
   const colOffsets = useMemo(() => {
-    const arr = new Array(cols + 1);
+    const arr = new Array(displayCols + 1);
     arr[0] = 0;
-    for (let i = 0; i < cols; i++) arr[i + 1] = arr[i] + getColW(i);
+    for (let i = 0; i < displayCols; i++) arr[i + 1] = arr[i] + getDisplayColW(i);
     return arr;
-  }, [cols, getColW]);
+  }, [displayCols, getDisplayColW]);
 
   const rowOffsets = useMemo(() => {
-    const arr = new Array(rows + 1);
+    const arr = new Array(displayRows + 1);
     arr[0] = 0;
-    for (let i = 0; i < rows; i++) arr[i + 1] = arr[i] + getRowH(i);
+    for (let i = 0; i < displayRows; i++) arr[i + 1] = arr[i] + getDisplayRowH(i);
     return arr;
-  }, [rows, getRowH]);
+  }, [displayRows, getDisplayRowH]);
 
   const selectedKey = selectedCell ? cellKey(selectedCell.row, selectedCell.col) : null;
   const selectedCellData = selectedKey ? cells[selectedKey] : null;
@@ -1547,8 +1630,8 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
                 color: 'var(--color-text-muted)',
               }}
             />
-            {Array.from({ length: cols }, (_, ci) => {
-              const w = getColW(ci);
+            {Array.from({ length: displayCols }, (_, ci) => {
+              const w = getDisplayColW(ci);
               const label = colLabel(ci);
               const isSelected = selRect && ci >= selRect.c1 && ci <= selRect.c2;
               return (
@@ -1576,8 +1659,8 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
           </div>
 
           {/* Rows */}
-          {Array.from({ length: rows }, (_, ri) => {
-            const rh = getRowH(ri);
+          {Array.from({ length: displayRows }, (_, ri) => {
+            const rh = getDisplayRowH(ri);
             const isRowSelected = selRect && ri >= selRect.r1 && ri <= selRect.r2;
             return (
               <div key={ri} className="flex" style={{ height: rh }}>
@@ -1597,7 +1680,7 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
                     className="absolute bottom-0 left-0 w-full h-[3px] cursor-row-resize z-10"
                   />
                 </div>
-                {Array.from({ length: cols }, (_, ci) => {
+                {Array.from({ length: displayCols }, (_, ci) => {
                   const mergeKey = `${ri},${ci}`;
                   const isMergeAnchor = mergeLookup.anchorMap.has(mergeKey);
                   const isMergeCovered = mergeLookup.coveredMap.has(mergeKey);
@@ -1606,7 +1689,7 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
                       <div
                         key={ci}
                         className="flex-shrink-0"
-                        style={{ width: getColW(ci), height: rh }}
+                        style={{ width: getDisplayColW(ci), height: rh }}
                       />
                     );
                   }
@@ -1614,7 +1697,7 @@ export default function DataGrid({ data, onChange, zoomPct = 100 }) {
                   const cellData = cells[key];
                   const dv = displayValues[key] ?? cellData?.v ?? '';
                   const displayStr = formatCellValue(dv, cellData?.s);
-                  const w = getColW(ci);
+                  const w = getDisplayColW(ci);
                   const isAnchor = selectedCell && selectedCell.row === ri && selectedCell.col === ci;
                   const inRange = selRect && ri >= selRect.r1 && ri <= selRect.r2 && ci >= selRect.c1 && ci <= selRect.c2;
                   const isEditing = editingCell && editingCell.row === ri && editingCell.col === ci;

--- a/src/components/ShapeLayer.jsx
+++ b/src/components/ShapeLayer.jsx
@@ -49,6 +49,7 @@ export default function ShapeLayer({
   onBeginTextEdit,
   onCommitText,
   onToggleTextFormat,
+  zoomFactor = 1,
 }) {
   const svgRef = useRef(null);
   const [gesture, setGesture] = useState(null);
@@ -69,8 +70,9 @@ export default function ShapeLayer({
     const svg = svgRef.current;
     if (!svg) return { x: 0, y: 0 };
     const rect = svg.getBoundingClientRect();
-    return { x: clientX - rect.left, y: clientY - rect.top };
-  }, []);
+    const zf = zoomFactor || 1;
+    return { x: (clientX - rect.left) / zf, y: (clientY - rect.top) / zf };
+  }, [zoomFactor]);
 
   // Apply the active gesture to a shape and return the effective visible shape.
   const effectiveShape = useCallback(

--- a/src/components/StatusBar.jsx
+++ b/src/components/StatusBar.jsx
@@ -12,6 +12,8 @@ export default function StatusBar({
   onScaleChange,
   zoomPct,
   onZoomChange,
+  gridZoomPct,
+  onGridZoomChange,
   activeTab,
   tabs,
   onSelectTab,
@@ -20,12 +22,16 @@ export default function StatusBar({
   onDeleteTab,
   onReorderTab,
 }) {
-  const [zoomInput, setZoomInput] = useState(String(zoomPct));
-  useEffect(() => { setZoomInput(String(zoomPct)); }, [zoomPct]);
+  const isGantt = activeTab === 'gantt';
+  const activeZoomPct = isGantt ? zoomPct : gridZoomPct;
+  const activeOnZoomChange = isGantt ? onZoomChange : onGridZoomChange;
+
+  const [zoomInput, setZoomInput] = useState(String(activeZoomPct));
+  useEffect(() => { setZoomInput(String(activeZoomPct)); }, [activeZoomPct]);
 
   const handleZoomStep = (direction) => {
-    const next = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, zoomPct + direction * ZOOM_STEP));
-    onZoomChange(next);
+    const next = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, activeZoomPct + direction * ZOOM_STEP));
+    activeOnZoomChange(next);
   };
 
   const handleZoomInputChange = (e) => {
@@ -33,7 +39,7 @@ export default function StatusBar({
     setZoomInput(raw);
     const parsed = parseInt(raw, 10);
     if (!isNaN(parsed) && parsed >= ZOOM_MIN && parsed <= ZOOM_MAX) {
-      onZoomChange(parsed);
+      activeOnZoomChange(parsed);
     }
   };
 
@@ -41,14 +47,12 @@ export default function StatusBar({
     const parsed = parseInt(zoomInput, 10);
     if (!isNaN(parsed)) {
       const clamped = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, Math.round(parsed)));
-      onZoomChange(clamped);
+      activeOnZoomChange(clamped);
       setZoomInput(String(clamped));
     } else {
-      setZoomInput(String(zoomPct));
+      setZoomInput(String(activeZoomPct));
     }
   };
-
-  const isGantt = activeTab === 'gantt';
 
   return (
     <div
@@ -85,36 +89,37 @@ export default function StatusBar({
         onReorderTab={onReorderTab}
       />
 
-      {/* Right: Scale + Zoom (visible only on Gantt tab) */}
-      {isGantt && (
-        <div className="flex items-center gap-1.5 flex-shrink-0">
-          <ScaleButton active={scale === 'day'} onClick={() => onScaleChange('day')} icon={Calendar} label="Day" />
-          <ScaleButton active={scale === 'week'} onClick={() => onScaleChange('week')} icon={CalendarDays} label="Week" />
-          <div className="w-px h-4 mx-0.5" style={{ backgroundColor: 'var(--color-border)' }} />
-          <ZoomButton icon={ZoomOut} onClick={() => handleZoomStep(-1)} disabled={zoomPct <= ZOOM_MIN} />
-          <input
-            type="number"
-            value={zoomInput}
-            min={ZOOM_MIN}
-            max={ZOOM_MAX}
-            step={1}
-            onChange={handleZoomInputChange}
-            onBlur={handleZoomInputCommit}
-            onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur(); }}
-            className="tabular-nums text-center font-medium bg-transparent outline-none border-b"
-            style={{
-              width: 34,
-              fontSize: 11,
-              color: 'var(--color-text-secondary)',
-              borderColor: 'var(--color-border)',
-              MozAppearance: 'textfield',
-            }}
-          />
-          <span className="text-[11px]" style={{ color: 'var(--color-text-muted)' }}>%</span>
-          <ZoomButton icon={ZoomIn} onClick={() => handleZoomStep(1)} disabled={zoomPct >= ZOOM_MAX} />
-        </div>
-      )}
-      {!isGantt && <div />}
+      {/* Right: Scale (Gantt only) + Zoom (all tabs) */}
+      <div className="flex items-center gap-1.5 flex-shrink-0">
+        {isGantt && (
+          <>
+            <ScaleButton active={scale === 'day'} onClick={() => onScaleChange('day')} icon={Calendar} label="Day" />
+            <ScaleButton active={scale === 'week'} onClick={() => onScaleChange('week')} icon={CalendarDays} label="Week" />
+            <div className="w-px h-4 mx-0.5" style={{ backgroundColor: 'var(--color-border)' }} />
+          </>
+        )}
+        <ZoomButton icon={ZoomOut} onClick={() => handleZoomStep(-1)} disabled={activeZoomPct <= ZOOM_MIN} />
+        <input
+          type="number"
+          value={zoomInput}
+          min={ZOOM_MIN}
+          max={ZOOM_MAX}
+          step={1}
+          onChange={handleZoomInputChange}
+          onBlur={handleZoomInputCommit}
+          onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur(); }}
+          className="tabular-nums text-center font-medium bg-transparent outline-none border-b"
+          style={{
+            width: 34,
+            fontSize: 11,
+            color: 'var(--color-text-secondary)',
+            borderColor: 'var(--color-border)',
+            MozAppearance: 'textfield',
+          }}
+        />
+        <span className="text-[11px]" style={{ color: 'var(--color-text-muted)' }}>%</span>
+        <ZoomButton icon={ZoomIn} onClick={() => handleZoomStep(1)} disabled={activeZoomPct >= ZOOM_MAX} />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The zoom in/out controls in the `StatusBar` were previously only rendered on the Gantt tab. This PR brings them to the datagrid (spreadsheet) tabs as well, using the same style and position as on Gantt.

## Changes

- `App.jsx`: added `gridZoom` state, `handleGridZoomChange` handler, and wired it into `StatusBar` + `DataGrid`. The value is persisted/restored via the `settings.gridZoom` field.
- `StatusBar.jsx`: the zoom input, +/- buttons, and `%` label now render on every tab. The Day/Week scale buttons remain Gantt-only (they are scale-axis specific).
- `DataGrid.jsx`:
  - accepts a `zoomPct` prop and applies CSS `zoom` to the inner grid content container;
  - pads the rendered grid with extra rows/columns (`displayRows` / `displayCols`) so the visible area is always filled, even when CSS zoom shrinks the content past the data-backed `rows`/`cols`. Persisted `rows`/`cols` still only grow when the user actually types into a cell (via the existing auto-expand path);
  - uses a `ResizeObserver` (rAF-batched to avoid feedback loops) on the scroll container to recompute padding when the viewport changes;
  - mouse-coordinate math for drag-select and column/row resize is divided by the zoom factor so interactions line up correctly at any zoom level.
- `ShapeLayer.jsx`: accepts a `zoomFactor` prop and converts visual-pixel client coordinates back into logical shape coordinates so drawing/move/resize/rotate still align after zoom.

## Notes

- Zoom range is 5%-300%, matching the Gantt control.
- Gantt zoom (`ganttZoom`) and grid zoom (`gridZoom`) are tracked independently so switching between tabs preserves each view's preferred zoom.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d2c8708-d4a2-455f-9aaf-edb61378759c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d2c8708-d4a2-455f-9aaf-edb61378759c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

