### PR TITLE
fix(wbs): roll up parent progress as duration-weighted average

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -162,41 +162,72 @@ function buildWbsTree(tasks, skipWeekends) {
     // pattern used by assignDepth(). Returning a neutral aggregate keeps the
     // caller's start/end/progress folding sane without polluting resultMap.
     if (!resultMap.has(taskId)) {
-      return { startDate: null, endDate: null, progress: 0 };
+      return { startDate: null, endDate: null, progress: 0, duration: 0 };
     }
     if (resolved.has(taskId)) {
       const t = resultMap.get(taskId);
-      return { startDate: t.startDate, endDate: t.endDate, progress: t.progress || 0 };
+      return {
+        startDate: t.startDate,
+        endDate: t.endDate,
+        progress: t.progress || 0,
+        duration: Number(t.duration) || 0,
+      };
     }
     resolved.add(taskId);
 
     const children = childrenMap.get(taskId);
     if (!children || children.length === 0) {
       const t = resultMap.get(taskId);
-      return { startDate: t.startDate, endDate: t.endDate, progress: t.progress || 0 };
+      return {
+        startDate: t.startDate,
+        endDate: t.endDate,
+        progress: t.progress || 0,
+        duration: Number(t.duration) || 0,
+      };
     }
 
     let minStart = null;
     let maxEnd = null;
+    // Weighted aggregation: a parent's progress is the share of its children's
+    // total planned duration that has been completed, i.e. sum(finished days) /
+    // sum(planned days). This matches how PM tools compute roll-up percent and
+    // ensures the parent reacts when any child's duration changes, not just its
+    // raw progress field. Falls back to a simple count-based average when no
+    // child has a positive duration (e.g. an all-milestone group).
     let totalProgress = 0;
+    let totalDuration = 0;
+    let totalFinishedDays = 0;
 
     for (const child of children) {
       const r = resolve(String(child.id));
       if (r.startDate && (!minStart || r.startDate < minStart)) minStart = r.startDate;
       if (r.endDate && (!maxEnd || r.endDate > maxEnd)) maxEnd = r.endDate;
-      totalProgress += r.progress;
+      const childDuration = Number(r.duration) || 0;
+      const childProgress = Number(r.progress) || 0;
+      totalProgress += childProgress;
+      totalDuration += childDuration;
+      totalFinishedDays += childDuration * (childProgress / 100);
     }
 
     const task = resultMap.get(taskId);
     task.isParent = true;
     task.startDate = minStart || task.startDate;
     task.endDate = maxEnd || task.endDate;
-    task.progress = children.length > 0 ? Math.round(totalProgress / children.length) : task.progress;
     task.duration = task.startDate && task.endDate
       ? workingDaysBetween(task.startDate, task.endDate, skipWeekends)
       : 0;
+    if (totalDuration > 0) {
+      task.progress = Math.round((totalFinishedDays / totalDuration) * 100);
+    } else if (children.length > 0) {
+      task.progress = Math.round(totalProgress / children.length);
+    }
 
-    return { startDate: task.startDate, endDate: task.endDate, progress: task.progress };
+    return {
+      startDate: task.startDate,
+      endDate: task.endDate,
+      progress: task.progress,
+      duration: task.duration,
+    };
   }
 
   for (const parentId of childrenMap.keys()) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a child task's duration is changed, the parent task's progress percentage stays the same, even though the share of the schedule that has been completed has clearly shifted.

## Root cause

`buildWbsTree` in `src/App.jsx` was rolling up child progress with a simple count-based average:

```js
task.progress = children.length > 0 ? Math.round(totalProgress / children.length) : task.progress;
```

Each child contributed equally to the parent regardless of how long it was, so changing a child's `duration` had no effect on the parent's `progress`.

## Fix

Switch the parent roll-up to a duration-weighted average, matching the formula in the issue:

```
parent.progress = sum(child.duration * child.progress) / sum(child.duration)
```

i.e. total finished days over total planned days. Now the parent recomputes whenever a child's duration *or* progress changes, because the parent's `progress` value is derived from both.

A guard keeps the old count-based average as a fallback when no child has a positive duration (e.g. an all-milestone group), so existing schedules with zero-duration children still produce a sensible number instead of dividing by zero.

The recomputation is already wired up reactively: `wbsTasks = useMemo(() => buildWbsTree(tasks, ...), [tasks, skipWeekends])`, so any task edit (including duration) triggers the parent recalculation on the next render.

## Files changed

- `src/App.jsx` -- updated the `resolve` helper inside `buildWbsTree` to track per-child planned days and finished days, and to derive parent progress from those sums.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e784b02-c31f-47d9-b66a-f42e6f7e31f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e784b02-c31f-47d9-b66a-f42e6f7e31f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

