### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+GanttGen is a single-package, client-side-only React SPA with zero backend dependencies. There is no database, no API server, and no environment variables or secrets required.
+
+### Quick reference
+
+| Action       | Command          |
+|------------- |------------------|
+| Install deps | `npm install`    |
+| Dev server   | `npm run dev`    |
+| Lint         | `npm run lint`   |
+| Build        | `npm run build`  |
+| Preview      | `npm run preview`|
+
+### Notes
+
+- The dev server (Vite) runs at `http://localhost:5173` by default.
+- The production build outputs a single self-contained `dist/index.html` (~1.5 MB) via `vite-plugin-singlefile`. All JS/CSS/assets are inlined.
+- The `xlsx` (SheetJS) dependency is fetched from `https://cdn.sheetjs.com`, not the npm registry. If network issues occur during `npm install`, this is the most likely cause.
+- ESLint has pre-existing warnings/errors in the codebase (mostly `no-unused-vars` and React hooks warnings). These are not blocking and are part of the current codebase state.
+- There are no automated tests (no test framework configured). Validation is done through lint and build.
+- Node.js 22 LTS is required. The environment comes with Node.js pre-installed via nodesource.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this codebase.

## What's included

- Quick reference table for all npm scripts (`dev`, `lint`, `build`, `preview`)
- Notes on the Vite dev server, single-file production build, and SheetJS dependency source
- Documentation of pre-existing ESLint warnings and the absence of automated tests

## Development environment verification

The following were verified during setup:

| Check | Status | Command |
|-------|--------|---------|
| Dependencies install | Pass | `npm install` |
| Lint | Pass (pre-existing warnings) | `npm run lint` |
| Production build | Pass | `npm run build` |
| Dev server | Pass (localhost:5173) | `npm run dev` |
| App interaction | Pass | Added tasks, edited cells, renamed project |

### Screenshot: App running with tasks created

[GanttGen running with demo tasks](https://cursor.com/agents/bc-b52cac14-a2b3-406b-8c99-314e22af3983/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F10-final-demo.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b52cac14-a2b3-406b-8c99-314e22af3983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b52cac14-a2b3-406b-8c99-314e22af3983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

